### PR TITLE
Adjust priority of ProtectionCrystal's PlayerDeathEvent

### DIFF
--- a/crazyenchantments/src/main/java/me/badbones69/crazyenchantments/controlers/ProtectionCrystal.java
+++ b/crazyenchantments/src/main/java/me/badbones69/crazyenchantments/controlers/ProtectionCrystal.java
@@ -64,7 +64,7 @@ public class ProtectionCrystal implements Listener {
 		}
 	}
 
-	@EventHandler(priority = EventPriority.MONITOR)
+	@EventHandler
 	public void onPlayerDeath(PlayerDeathEvent e) {
 		Player player = e.getEntity();
 		ArrayList<ItemStack> items = new ArrayList<>();


### PR DESCRIPTION
`MONITOR` priority is intended to be used to monitor the event status, not to modify it.

This provides compatibility with plugins that modify drops such as death chests or direct inventory transfer to the killer.