### PR TITLE
Fix rage spam on chat.

### DIFF
--- a/src/main/java/me/badbones69/crazyenchantments/enchantments/Swords.java
+++ b/src/main/java/me/badbones69/crazyenchantments/enchantments/Swords.java
@@ -147,6 +147,7 @@ public class Swords implements Listener {
 											}
 											if(!cePlayer.hasRage()) {
 												cePlayer.setRageMultiplyer(1.0);
+												cePlayer.setRage(true);
 												cePlayer.setRageLevel(1);
 												if(Messages.RAGE_BUILDING.getMessage().length() > 0) {
 													damager.sendMessage(Messages.RAGE_BUILDING.getMessage());


### PR DESCRIPTION
Previously hasRage was never set true, so it was always appearing to be in the starting state.
This would cause "rage is building" spam on the client chat.