### PR TITLE
Enable other plugins to handle BlockBreakEvent

### DIFF
--- a/src/main/java/me/badbones69/crazyenchantments/enchantments/PickAxes.java
+++ b/src/main/java/me/badbones69/crazyenchantments/enchantments/PickAxes.java
@@ -325,7 +325,7 @@ public class PickAxes implements Listener {
 											}
 										}
 									}
-									block.setType(Material.AIR);
+									e.setDropItems(false);
 									Methods.removeDurability(item, player);
 								}
 							}
@@ -358,7 +358,7 @@ public class PickAxes implements Listener {
 										}
 									}
 								}
-								block.setType(Material.AIR);
+								e.setDropItems(false);
 								Methods.removeDurability(item, player);
 							}
 						}

--- a/src/main/java/me/badbones69/crazyenchantments/enchantments/Tools.java
+++ b/src/main/java/me/badbones69/crazyenchantments/enchantments/Tools.java
@@ -166,7 +166,7 @@ public class Tools implements Listener {
 									player.getInventory().addItem(i);
 								}
 							}
-							block.setType(Material.AIR);
+							e.setDropItems(false);
 							Methods.removeDurability(item, player);
 						}
 					}


### PR DESCRIPTION
Disable drop items instead of setting to air.

This means other plugins can still react to the BlockBreakEvent, whereas when set to air they don't.
I found this made CE Telepathy as implemented in Tools.java play nicely with other plugins that count block breaks (like achievement plugins). The changes in PickAxes.java were made as copies of the same idea but not specifically tested.