### PR TITLE
Make lightning sound local to player

### DIFF
--- a/src/main/java/me/badbones69/crazyenchantments/enchantments/Armor.java
+++ b/src/main/java/me/badbones69/crazyenchantments/enchantments/Armor.java
@@ -13,6 +13,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
+import org.bukkit.Sound;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -243,7 +244,8 @@ public class Armor implements Listener {
 									Bukkit.getPluginManager().callEvent(event);
 									if(!event.isCancelled()) {
 										Location loc = damager.getLocation();
-										loc.getWorld().strikeLightningEffect(loc);
+										loc.getWorld().spigot().strikeLightningEffect(loc,true);
+										loc.getWorld().playSound(loc, Sound.ENTITY_LIGHTNING_BOLT_IMPACT,1,1);
 										for(LivingEntity en : Methods.getNearbyLivingEntities(loc, 2D, damager)) {
 											if(Support.allowsPVP(en.getLocation())) {
 												if(!Support.isFriendly(player, en)) {

--- a/src/main/java/me/badbones69/crazyenchantments/enchantments/Bows.java
+++ b/src/main/java/me/badbones69/crazyenchantments/enchantments/Bows.java
@@ -12,6 +12,7 @@ import me.badbones69.crazyenchantments.multisupport.Support.SupportedPlugins;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -124,7 +125,8 @@ public class Bows implements Listener {
 					if(CEnchantments.LIGHTNING.isActivated()) {
 						Location loc = arrow.getArrow().getLocation();
 						if(CEnchantments.LIGHTNING.chanceSuccessful(arrow.getBow())) {
-							loc.getWorld().strikeLightningEffect(loc);
+							loc.getWorld().spigot().strikeLightningEffect(loc,true);
+							loc.getWorld().playSound(loc, Sound.ENTITY_LIGHTNING_BOLT_IMPACT,1,1);
 							for(LivingEntity entity : Methods.getNearbyLivingEntities(loc, 2D, arrow.getArrow())) {
 								if(Support.allowsPVP(entity.getLocation())) {
 									if(!Support.isFriendly(arrow.getShooter(), entity)) {

--- a/src/main/java/me/badbones69/crazyenchantments/enchantments/Swords.java
+++ b/src/main/java/me/badbones69/crazyenchantments/enchantments/Swords.java
@@ -17,6 +17,7 @@ import me.badbones69.crazyenchantments.multisupport.Support.SupportedPlugins;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -333,7 +334,8 @@ public class Swords implements Listener {
 											Bukkit.getPluginManager().callEvent(event);
 											if(!event.isCancelled()) {
 												Location loc = en.getLocation();
-												loc.getWorld().strikeLightningEffect(loc);
+												loc.getWorld().spigot().strikeLightningEffect(loc,true);
+												loc.getWorld().playSound(loc, Sound.ENTITY_LIGHTNING_BOLT_IMPACT,1,1);
 												for(LivingEntity En : Methods.getNearbyLivingEntities(loc, 2D, damager)) {
 													if(Support.allowsPVP(En.getLocation())) {
 														if(!Support.isFriendly(damager, En)) {


### PR DESCRIPTION
Lightning sound is now heard by only those in the vicinity of the blast instead of server-wide like environmental/weather lightning.

NOTE: The drop-off in volume is quite a lot. A bow shot needs to be quite close to hear the sound. 
Perhaps someone else knows how to reduce the drop-off or similar. Potentially for bows only (not swords or armour) it could play the sound directly to the player shooting the bow to give that audio feedback of the enchantment.
[Edit] Let me know if you'd want that addition because I have a local commit that was playing the sound to the player instead. I can combine the two for bows (as long as that doesn't end up with a double sound for the player using the bow).