### PR TITLE
Add configurable range for lightning sound

### DIFF
--- a/src/main/java/me/badbones69/crazyenchantments/enchantments/Armor.java
+++ b/src/main/java/me/badbones69/crazyenchantments/enchantments/Armor.java
@@ -4,6 +4,7 @@ import me.badbones69.crazyenchantments.Methods;
 import me.badbones69.crazyenchantments.api.CrazyEnchantments;
 import me.badbones69.crazyenchantments.api.enums.CEnchantments;
 import me.badbones69.crazyenchantments.api.events.*;
+import me.badbones69.crazyenchantments.api.objects.FileManager.Files;
 import me.badbones69.crazyenchantments.controllers.ProtectionCrystal;
 import me.badbones69.crazyenchantments.multisupport.AACSupport;
 import me.badbones69.crazyenchantments.multisupport.SpartanSupport;
@@ -241,7 +242,8 @@ public class Armor implements Listener {
 									if(!event.isCancelled()) {
 										Location loc = damager.getLocation();
 										loc.getWorld().spigot().strikeLightningEffect(loc, true);
-										loc.getWorld().playSound(loc, Sound.ENTITY_LIGHTNING_BOLT_IMPACT, 1, 1);
+										int lightningSoundRange = Files.CONFIG.getFile().getInt("Settings.EnchantmentOptions.Lightning-Sound-Range", 160 );
+										loc.getWorld().playSound(loc, Sound.ENTITY_LIGHTNING_BOLT_IMPACT, (float)lightningSoundRange / 16f, 1);
 										for(LivingEntity en : Methods.getNearbyLivingEntities(loc, 2D, damager)) {
 											if(Support.allowsPVP(en.getLocation())) {
 												if(!Support.isFriendly(player, en)) {

--- a/src/main/java/me/badbones69/crazyenchantments/enchantments/Bows.java
+++ b/src/main/java/me/badbones69/crazyenchantments/enchantments/Bows.java
@@ -5,6 +5,7 @@ import me.badbones69.crazyenchantments.api.CrazyEnchantments;
 import me.badbones69.crazyenchantments.api.enums.CEnchantments;
 import me.badbones69.crazyenchantments.api.events.EnchantmentUseEvent;
 import me.badbones69.crazyenchantments.api.objects.EnchantedArrow;
+import me.badbones69.crazyenchantments.api.objects.FileManager;
 import me.badbones69.crazyenchantments.multisupport.AACSupport;
 import me.badbones69.crazyenchantments.multisupport.SpartanSupport;
 import me.badbones69.crazyenchantments.multisupport.Support;
@@ -158,7 +159,8 @@ public class Bows implements Listener {
 						Location loc = arrow.getArrow().getLocation();
 						if(CEnchantments.LIGHTNING.chanceSuccessful(arrow.getBow())) {
 							loc.getWorld().spigot().strikeLightningEffect(loc, true);
-							loc.getWorld().playSound(loc, Sound.ENTITY_LIGHTNING_BOLT_IMPACT, 1, 1);
+							int lightningSoundRange = FileManager.Files.CONFIG.getFile().getInt("Settings.EnchantmentOptions.Lightning-Sound-Range", 160 );
+							loc.getWorld().playSound(loc, Sound.ENTITY_LIGHTNING_BOLT_IMPACT, (float)lightningSoundRange / 16f, 1);
 							for(LivingEntity entity : Methods.getNearbyLivingEntities(loc, 2D, arrow.getArrow())) {
 								if(Support.allowsPVP(entity.getLocation())) {
 									if(!Support.isFriendly(arrow.getShooter(), entity)) {

--- a/src/main/java/me/badbones69/crazyenchantments/enchantments/Swords.java
+++ b/src/main/java/me/badbones69/crazyenchantments/enchantments/Swords.java
@@ -10,6 +10,7 @@ import me.badbones69.crazyenchantments.api.events.DisarmerUseEvent;
 import me.badbones69.crazyenchantments.api.events.EnchantmentUseEvent;
 import me.badbones69.crazyenchantments.api.events.RageBreakEvent;
 import me.badbones69.crazyenchantments.api.objects.CEPlayer;
+import me.badbones69.crazyenchantments.api.objects.FileManager;
 import me.badbones69.crazyenchantments.api.objects.ItemBuilder;
 import me.badbones69.crazyenchantments.multisupport.SpartanSupport;
 import me.badbones69.crazyenchantments.multisupport.Support;
@@ -336,7 +337,8 @@ public class Swords implements Listener {
 											if(!event.isCancelled()) {
 												Location loc = en.getLocation();
 												loc.getWorld().spigot().strikeLightningEffect(loc, true);
-												loc.getWorld().playSound(loc, Sound.ENTITY_LIGHTNING_BOLT_IMPACT, 1, 1);
+												int lightningSoundRange = FileManager.Files.CONFIG.getFile().getInt("Settings.EnchantmentOptions.Lightning-Sound-Range", 160 );
+												loc.getWorld().playSound(loc, Sound.ENTITY_LIGHTNING_BOLT_IMPACT, (float)lightningSoundRange / 16f, 1);
 												for(LivingEntity En : Methods.getNearbyLivingEntities(loc, 2D, damager)) {
 													if(Support.allowsPVP(En.getLocation())) {
 														if(!Support.isFriendly(damager, En)) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -253,6 +253,7 @@ Settings:
     Blast-Full-Durability: true #Toggle if the item takes damage for every block it breaks or just one. True to take full damage or false to take only 1 damage.
     Right-Click-Enchantment-Table: false #When set to true if a player right clicks an enchantment table it will open the /CE gui.
     EXP-Bug: false #Only needs to be true if player's XP sometimes glitches to 1Bill after buying an item will all their XP.
+    Lightning-Sound-Range: 160 #Range in blocks where lightning sound should become inaudible.
     Armor-Upgrade: #Having this enabled will allow players to try and add a higher level of an enchantment onto an item with a lower level of the enchantment.
       Toggle: true #Toggle on or off the ability to upgrade the enchantments.
       Enchantment-Break: true #If the book's destroy rate happens the item doesn't break but instead the current lower version of the enchantment is destroyed. If false then the item will be destroyed instead.


### PR DESCRIPTION
New config item:
    Settings.EnchantmentOptions.Lightning-Sound-Range: 160
Default sets blast to be inaudible at 160 blocks.