### PR TITLE
Ensure blast pick always breaks target block

### DIFF
--- a/plugin/src/main/java/me/badbones69/crazyenchantments/enchantments/PickAxes.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/enchantments/PickAxes.java
@@ -84,6 +84,7 @@ public class PickAxes implements Listener {
 									}
 								}
 							}
+							Location originalBlockLocation = block.getLocation();
 							new BukkitRunnable() { // Run async to help offload some lag.
 								@Override
 								public void run() {
@@ -108,7 +109,7 @@ public class PickAxes implements Listener {
 									boolean hasSilkTouch = item.getItemMeta().hasEnchant(Enchantment.SILK_TOUCH);
 									boolean hasExperience = ce.hasEnchantment(item, CEnchantments.EXPERIENCE);
 									for(Block block : finalBlockList) {
-										if(ce.getBlockList().contains(block.getType())) {
+										if(ce.getBlockList().contains(block.getType()) || block.getLocation().equals(originalBlockLocation)) {
 											if(player.getGameMode() == GameMode.CREATIVE) { //If the user is in creative mode.
 												new BukkitRunnable() {
 													@Override


### PR DESCRIPTION
When the allowed block list was limited, a blast pick no longer broke the target block unless it was in the block list.
With this change, a blast pick always breaks at least the target block even if it's not in the allowed block list.