### PR TITLE
Stop firing BlockBreakEvent for blocks that won't be broken

### DIFF
--- a/plugin/src/main/java/me/badbones69/crazyenchantments/enchantments/PickAxes.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/enchantments/PickAxes.java
@@ -75,19 +75,21 @@ public class PickAxes implements Listener {
 						BlastUseEvent blastUseEvent = new BlastUseEvent(player, blockList);
 						Bukkit.getPluginManager().callEvent(blastUseEvent);
 						if(!blastUseEvent.isCancelled()) {
+							Location originalBlockLocation = block.getLocation();
 							List<Block> finalBlockList = new ArrayList<>();
 							for(Block b : blockList) {
 								if(b.getType() != Material.AIR) {
-									BlockBreakEvent event = new BlockBreakEvent(b, player);
-									ce.addBreakEvent(event);
-									Bukkit.getPluginManager().callEvent(event);
-									if(!event.isCancelled()) { //This stops players from breaking blocks that might be in protected areas.
-										finalBlockList.add(b);
-										ce.removeBreakEvent(event);
+									if(ce.getBlockList().contains(b.getType()) || b.getLocation().equals(originalBlockLocation)) {
+										BlockBreakEvent event = new BlockBreakEvent(b, player);
+										ce.addBreakEvent(event);
+										Bukkit.getPluginManager().callEvent(event);
+										if(!event.isCancelled()) { //This stops players from breaking blocks that might be in protected areas.
+											finalBlockList.add(b);
+											ce.removeBreakEvent(event);
+										}
 									}
 								}
 							}
-							Location originalBlockLocation = block.getLocation();
 							new BukkitRunnable() { // Run async to help offload some lag.
 								@Override
 								public void run() {
@@ -112,150 +114,148 @@ public class PickAxes implements Listener {
 									boolean hasSilkTouch = item.getItemMeta().hasEnchant(Enchantment.SILK_TOUCH);
 									boolean hasExperience = enchantments.contains(CEnchantments.EXPERIENCE.getEnchantment());
 									for(Block block : finalBlockList) {
-										if(ce.getBlockList().contains(block.getType()) || block.getLocation().equals(originalBlockLocation)) {
-											if(player.getGameMode() == GameMode.CREATIVE) { //If the user is in creative mode.
-												new BukkitRunnable() {
-													@Override
-													public void run() {
-														block.setType(Material.AIR);
-													}
-												}.runTask(ce.getPlugin());
-											}else { //If the user is in survival mode.
-												boolean toggle = true; //True means its air and false means it breaks normally.
-												if(hasTelepathy) {
-													for(ItemStack drop : block.getDrops()) {
-														if(hasFurnace && isOre(block.getType())) {
+										if(player.getGameMode() == GameMode.CREATIVE) { //If the user is in creative mode.
+											new BukkitRunnable() {
+												@Override
+												public void run() {
+													block.setType(Material.AIR);
+												}
+											}.runTask(ce.getPlugin());
+										}else { //If the user is in survival mode.
+											boolean toggle = true; //True means its air and false means it breaks normally.
+											if(hasTelepathy) {
+												for(ItemStack drop : block.getDrops()) {
+													if(hasFurnace && isOre(block.getType())) {
+														drop = getOreDrop(block.getType());
+														if(hasLootingBonusBlocks) {
+															if(Methods.randomPicker(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS), 3)) {
+																drop.setAmount(Methods.getRandomNumber(1 + item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS)));
+															}
+														}
+													}else if(hasAutoSmelt && isOre(block.getType())) {
+														if(CEnchantments.AUTOSMELT.chanceSuccessful(item)) {
 															drop = getOreDrop(block.getType());
+															drop.setAmount(1 + ce.getLevel(item, CEnchantments.AUTOSMELT));
+															if(hasLootingBonusBlocks) {
+																if(Methods.randomPicker(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS), 3)) {
+																	drop.setAmount(drop.getAmount() + Methods.getRandomNumber(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS)));
+																}
+															}
+														}
+													}else {
+														if(getItems().contains(block.getType())) {
 															if(hasLootingBonusBlocks) {
 																if(Methods.randomPicker(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS), 3)) {
 																	drop.setAmount(Methods.getRandomNumber(1 + item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS)));
 																}
 															}
-														}else if(hasAutoSmelt && isOre(block.getType())) {
-															if(CEnchantments.AUTOSMELT.chanceSuccessful(item)) {
-																drop = getOreDrop(block.getType());
-																drop.setAmount(1 + ce.getLevel(item, CEnchantments.AUTOSMELT));
-																if(hasLootingBonusBlocks) {
-																	if(Methods.randomPicker(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS), 3)) {
-																		drop.setAmount(drop.getAmount() + Methods.getRandomNumber(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS)));
-																	}
-																}
+														}
+													}
+													if(item.getItemMeta().hasEnchants()) {
+														if(hasSilkTouch) {
+															if(block.getType() == Material.REDSTONE_ORE) {
+																drop = new ItemStack(Material.REDSTONE_ORE, 1, block.getData());
+															}else {
+																drop = new ItemStack(block.getType(), 1, block.getData());
 															}
-														}else {
-															if(getItems().contains(block.getType())) {
-																if(hasLootingBonusBlocks) {
-																	if(Methods.randomPicker(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS), 3)) {
-																		drop.setAmount(Methods.getRandomNumber(1 + item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS)));
-																	}
+														}
+													}
+													int amount = drop.getAmount();
+													if(drops.containsKey(drop)) {
+														drops.put(drop, drops.get(drop) + amount);
+													}else {
+														drops.put(drop, amount);
+													}
+													if(drop.getType() == Material.REDSTONE_ORE || drop.getType() == Material.REDSTONE_ORE || drop.getType() == Material.LAPIS_ORE || drop.getType() == Material.GLOWSTONE) {
+														break;
+													}
+												}
+											}else {
+												boolean fortune = false;
+												if(hasFurnace && isOre(block.getType())) {
+													for(ItemStack drop : block.getDrops()) {
+														drop = getOreDrop(block.getType());
+														if(hasLootingBonusBlocks) {
+															if(Methods.randomPicker(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS), 3)) {
+																drop.setAmount(1 + item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS));
+															}
+														}
+														ItemStack finalDrop = drop;
+														new BukkitRunnable() {
+															@Override
+															public void run() {
+																block.getWorld().dropItem(block.getLocation(), getOreDrop(block.getType(), finalDrop.getAmount()));
+															}
+														}.runTask(ce.getPlugin());
+													}
+												}else if(hasAutoSmelt && isOre(block.getType())) {
+													for(ItemStack drop : block.getDrops()) {
+														if(CEnchantments.AUTOSMELT.chanceSuccessful(item)) {
+															drop = getOreDrop(block.getType());
+															drop.setAmount(ce.getLevel(item, CEnchantments.AUTOSMELT));
+															if(hasLootingBonusBlocks) {
+																if(Methods.randomPicker(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS), 3)) {
+																	drop.setAmount(drop.getAmount() + Methods.getRandomNumber(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS)));
 																}
 															}
 														}
-														if(item.getItemMeta().hasEnchants()) {
-															if(hasSilkTouch) {
-																if(block.getType() == Material.REDSTONE_ORE) {
-																	drop = new ItemStack(Material.REDSTONE_ORE, 1, block.getData());
-																}else {
-																	drop = new ItemStack(block.getType(), 1, block.getData());
+														ItemStack finalDrop = drop;
+														new BukkitRunnable() {
+															@Override
+															public void run() {
+																block.getWorld().dropItem(block.getLocation(), finalDrop);
+															}
+														}.runTask(ce.getPlugin());
+													}
+												}else {
+													for(ItemStack drop : block.getDrops()) {
+														if(getItems().contains(block.getType())) {
+															if(hasLootingBonusBlocks) {
+																if(Methods.randomPicker(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS), 3)) {
+																	drop.setAmount(drop.getAmount() + Methods.getRandomNumber(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS)));
 																}
 															}
 														}
-														int amount = drop.getAmount();
-														if(drops.containsKey(drop)) {
-															drops.put(drop, drops.get(drop) + amount);
-														}else {
-															drops.put(drop, amount);
+														if(hasSilkTouch) {
+															if(block.getType() == Material.REDSTONE_ORE) {
+																drop = new ItemStack(Material.REDSTONE_ORE, 1, block.getData());
+															}else {
+																drop = new ItemStack(block.getType(), 1, block.getData());
+															}
 														}
+														ItemStack finalDrop = drop;
+														new BukkitRunnable() {
+															@Override
+															public void run() {
+																block.getWorld().dropItem(block.getLocation(), finalDrop);
+															}
+														}.runTask(ce.getPlugin());
 														if(drop.getType() == Material.REDSTONE_ORE || drop.getType() == Material.REDSTONE_ORE || drop.getType() == Material.LAPIS_ORE || drop.getType() == Material.GLOWSTONE) {
 															break;
 														}
 													}
-												}else {
-													boolean fortune = false;
-													if(hasFurnace && isOre(block.getType())) {
-														for(ItemStack drop : block.getDrops()) {
-															drop = getOreDrop(block.getType());
-															if(hasLootingBonusBlocks) {
-																if(Methods.randomPicker(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS), 3)) {
-																	drop.setAmount(1 + item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS));
-																}
-															}
-															ItemStack finalDrop = drop;
-															new BukkitRunnable() {
-																@Override
-																public void run() {
-																	block.getWorld().dropItem(block.getLocation(), getOreDrop(block.getType(), finalDrop.getAmount()));
-																}
-															}.runTask(ce.getPlugin());
-														}
-													}else if(hasAutoSmelt && isOre(block.getType())) {
-														for(ItemStack drop : block.getDrops()) {
-															if(CEnchantments.AUTOSMELT.chanceSuccessful(item)) {
-																drop = getOreDrop(block.getType());
-																drop.setAmount(ce.getLevel(item, CEnchantments.AUTOSMELT));
-																if(hasLootingBonusBlocks) {
-																	if(Methods.randomPicker(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS), 3)) {
-																		drop.setAmount(drop.getAmount() + Methods.getRandomNumber(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS)));
-																	}
-																}
-															}
-															ItemStack finalDrop = drop;
-															new BukkitRunnable() {
-																@Override
-																public void run() {
-																	block.getWorld().dropItem(block.getLocation(), finalDrop);
-																}
-															}.runTask(ce.getPlugin());
-														}
-													}else {
-														for(ItemStack drop : block.getDrops()) {
-															if(getItems().contains(block.getType())) {
-																if(hasLootingBonusBlocks) {
-																	if(Methods.randomPicker(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS), 3)) {
-																		drop.setAmount(drop.getAmount() + Methods.getRandomNumber(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS)));
-																	}
-																}
-															}
-															if(hasSilkTouch) {
-																if(block.getType() == Material.REDSTONE_ORE) {
-																	drop = new ItemStack(Material.REDSTONE_ORE, 1, block.getData());
-																}else {
-																	drop = new ItemStack(block.getType(), 1, block.getData());
-																}
-															}
-															ItemStack finalDrop = drop;
-															new BukkitRunnable() {
-																@Override
-																public void run() {
-																	block.getWorld().dropItem(block.getLocation(), finalDrop);
-																}
-															}.runTask(ce.getPlugin());
-															if(drop.getType() == Material.REDSTONE_ORE || drop.getType() == Material.REDSTONE_ORE || drop.getType() == Material.LAPIS_ORE || drop.getType() == Material.GLOWSTONE) {
-																break;
-															}
-														}
-													}
-												}
-												if(hasExperience) {
-													if(CEnchantments.EXPERIENCE.chanceSuccessful(item)) {
-														int power = ce.getLevel(item, CEnchantments.EXPERIENCE);
-														if(isOre(block.getType())) {
-															xp += Methods.percentPick(7, 3) * power;
-														}
-													}
-												}
-												new BukkitRunnable() {
-													@Override
-													public void run() {
-														block.setType(Material.AIR);
-													}
-												}.runTask(ce.getPlugin());
-												if(damage) {
-													Methods.removeDurability(item, player);
 												}
 											}
-											if(isOre(block.getType())) {
-												xp += Methods.percentPick(7, 3);
+											if(hasExperience) {
+												if(CEnchantments.EXPERIENCE.chanceSuccessful(item)) {
+													int power = ce.getLevel(item, CEnchantments.EXPERIENCE);
+													if(isOre(block.getType())) {
+														xp += Methods.percentPick(7, 3) * power;
+													}
+												}
 											}
+											new BukkitRunnable() {
+												@Override
+												public void run() {
+													block.setType(Material.AIR);
+												}
+											}.runTask(ce.getPlugin());
+											if(damage) {
+												Methods.removeDurability(item, player);
+											}
+										}
+										if(isOre(block.getType())) {
+											xp += Methods.percentPick(7, 3);
 										}
 									}
 									if(!damage) {


### PR DESCRIPTION
BlockBreakEvent was fired for all blocks in range of BLAST; however, blocks not in the blast block list would then not be broken.
Other plugins would react to the BlockBreakEvent (e.g. spawner mining plugins) and drop a block, causing a duplication.