### PR TITLE
Prevent armor aura effects on or from vanished players

### DIFF
--- a/plugin/src/main/java/me/badbones69/crazyenchantments/enchantments/Armor.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/enchantments/Armor.java
@@ -319,6 +319,8 @@ public class Armor implements Listener {
 	public void onAura(AuraActiveEvent e) {
 		Player player = e.getPlayer();
 		Player other = e.getOther();
+		if(!player.canSee(other) || !other.canSee(player)) return;
+		if(Support.isVanished(player) || Support.isVanished(other)) return;
 		CEnchantments enchant = e.getEnchantment();
 		int power = e.getPower();
 		if(!Methods.hasPermission(other, "bypass.aura", false)) {

--- a/plugin/src/main/java/me/badbones69/crazyenchantments/multisupport/Support.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/multisupport/Support.java
@@ -9,6 +9,7 @@ import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.Plugin;
 
 public class Support {
@@ -128,6 +129,13 @@ public class Support {
 			if(SupportedPlugins.GRIEF_PREVENTION.isPluginLoaded()) {
 				return GriefPreventionSupport.isFriendly(player, other);
 			}
+		}
+		return false;
+	}
+	
+	public static boolean isVanished(Entity p) {
+		for(MetadataValue meta : p.getMetadata("vanished")) {
+			if(meta.asBoolean()) return true;
 		}
 		return false;
 	}


### PR DESCRIPTION
Stops staff affecting or being affected by players while vanished.
isVanished implemented as per SuperVanish page, https://www.spigotmc.org/resources/supervanish-be-invisible.1331/