### PR TITLE
Fixes issue #422 - Multiarrow can be picked up

### DIFF
--- a/plugin/src/main/java/me/badbones69/crazyenchantments/enchantments/Bows.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/enchantments/Bows.java
@@ -16,6 +16,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.AbstractArrow;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
@@ -71,6 +72,7 @@ public class Bows implements Listener {
 										if(e.getProjectile().getFireTicks() > 0) {
 											spawnedArrow.setFireTicks(e.getProjectile().getFireTicks());
 										}
+										spawnedArrow.setPickupStatus(AbstractArrow.PickupStatus.DISALLOWED);
 									}
 								}
 							}else {
@@ -86,6 +88,7 @@ public class Bows implements Listener {
 									if(e.getProjectile().getFireTicks() > 0) {
 										spawnedArrow.setFireTicks(e.getProjectile().getFireTicks());
 									}
+									spawnedArrow.setPickupStatus(AbstractArrow.PickupStatus.DISALLOWED);
 								}
 							}
 						}


### PR DESCRIPTION
Tested with and without infinity.
Affects only the extra arrows from MultiArrow.
Single primary arrow can still be picked up if the bow does not have infinity.