### PR TITLE
Improve the PlotSquared hook

### DIFF
--- a/v1_13_up/pom.xml
+++ b/v1_13_up/pom.xml
@@ -24,8 +24,8 @@
         </repository>
         <!-- PlotSquared -->
         <repository>
-            <id>plotsquared</id>
-            <url>https://plotsquared.com/mvn/</url>
+            <id>IntellectualSites</id>
+            <url>https://mvn.intellectualsites.com/content/groups/public/</url>
         </repository>
     </repositories>
 
@@ -75,8 +75,8 @@
         <!-- PlotSquared API -->
         <dependency>
             <groupId>com.plotsquared</groupId>
-            <artifactId>PlotSquared</artifactId>
-            <version>5.1</version>
+            <artifactId>PlotSquared-Bukkit</artifactId>
+            <version>5.12.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/v1_13_up/src/main/java/me/badbones69/crazyenchantments/multisupport/plotsquared/PlotSquared.java
+++ b/v1_13_up/src/main/java/me/badbones69/crazyenchantments/multisupport/plotsquared/PlotSquared.java
@@ -1,5 +1,6 @@
 package me.badbones69.crazyenchantments.multisupport.plotsquared;
 
+import com.plotsquared.bukkit.util.BukkitUtil;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import org.bukkit.entity.Player;
@@ -7,12 +8,12 @@ import org.bukkit.entity.Player;
 public class PlotSquared implements PlotSquaredVersion {
     
     public boolean inTerritory(Player player) {
-        Plot plot = PlotPlayer.get(player.getName()).getCurrentPlot();
-        try {
-            return plot.getOwners().contains(player.getUniqueId()) || plot.getMembers().contains(player.getUniqueId());
-        } catch (Exception e) {
+        PlotPlayer<Player> plotPlayer = BukkitUtil.getPlayer(player);
+        Plot plot = plotPlayer.getCurrentPlot();
+        if (plot == null) {
             return false;
         }
+        return plot.isAdded(plotPlayer.getUUID());
     }
     
 }


### PR DESCRIPTION
Properly retrieve plot players and check for complete membership instead. Also added a null check to the plot getter rather than waiting for an NPE.

This will work for all membership tiers, as the previous code skipped trusted players. This also respects the PlotSquared UUID settings, which means it now also works for offline mode servers.

Side note, the maven setup is quite broken and half of the dependencies cannot be resolved. Most significantly, the AAC version used isn't available. Might want to look into that.