### PR TITLE
Update NBT-API to work with 1.16.4

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -105,7 +105,7 @@
         <dependency> <!-- NBT-API -->
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
-            <version>2.5.0</version>
+            <version>2.6.0</version>
         </dependency>
         <dependency> <!-- MCMMO -->
             <groupId>com.gmail.nossr50.mcMMO</groupId>


### PR DESCRIPTION
There were some issues in the 2.5.0 version that prevented it from working with 1.16.4, this update fixes it.