### PR TITLE
Fix Blacksmith bypass for CE Limits

### DIFF
--- a/plugin/src/main/java/me/badbones69/crazyenchantments/api/objects/BlackSmithResult.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/api/objects/BlackSmithResult.java
@@ -73,7 +73,7 @@ public class BlackSmithResult {
                 }
                 for (Entry<CEnchantment, Integer> entry : compare.getNewCEnchantments().entrySet()) {
                     CEnchantment enchantment = entry.getKey();
-                    if (enchantment.canEnchantItem(subItem) && ce.canAddEnchantment(player, mainItem)) {
+                    if (enchantment.canEnchantItem(subItem) && ce.canAddEnchantment(player, mainItem) && ce.canAddEnchantment(player, subItem)) {
                         mainCE.setCEnchantment(enchantment, entry.getValue());
                         cost += blackSmithManager.getAddEnchantment();
                     }


### PR DESCRIPTION
This just add a missing `canAddEnchantment()` check for the subItem, fixes issue #554.
Tested in PaperSpigot 1.8.8 for one day with no issues.