### PR TITLE
Fix AllyMobs targeting other AllyMobs from the same owner

### DIFF
--- a/plugin/src/main/java/me/badbones69/crazyenchantments/enchantments/AllyEnchantments.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/enchantments/AllyEnchantments.java
@@ -103,12 +103,20 @@ public class AllyEnchantments implements Listener {
             }
         }
     }
-    
+   
     @EventHandler
     public void onAllyTarget(EntityTargetEvent e) {
-        if (e.getTarget() instanceof Player && e.getEntity() instanceof LivingEntity) {
-            if (allyManager.isAlly((Player) e.getTarget(), (LivingEntity) e.getEntity())) {
-                e.setCancelled(true);
+        if (e.getEntity() instanceof LivingEntity) {
+            if(e.getTarget() instanceof Player) {
+                if (allyManager.isAlly((Player) e.getTarget(), (LivingEntity) e.getEntity())) {
+                    e.setCancelled(true);
+                }
+            } else if (e.getTarget() instanceof LivingEntity) {
+                if (allyManager.isAllyMob(e.getTarget()) && allyManager.isAllyMob(e.getEntity())) {
+                    if(allyManager.getAllyMob(e.getTarget()).getOwner().getUniqueId() == allyManager.getAllyMob(e.getEntity()).getOwner().getUniqueId()) {
+                        e.setCancelled(true);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Guards and Tamer mobs resort to attacking Infestation and Necromancer mobs from the same owner when the owner is not attacking anything else, effectively rendering the latter to be mutually exclusive with the former. 

Cancels the EntityTargetEvent if a mob and the mob it is targeting are AllyMobs and if they have the same owner.

