### PR TITLE
Fixes #575

### DIFF
--- a/plugin/src/main/java/me/badbones69/crazyenchantments/enchantments/Armor.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/enchantments/Armor.java
@@ -180,7 +180,7 @@ public class Armor implements Listener {
                                     }
                                 }.runTask(ce.getPlugin());
                             }
-                            if (ce.hasEnchantment(armor, CEnchantments.ENLIGHTENED) && CEnchantments.ENLIGHTENED.chanceSuccessful(armor)) {
+                            if (ce.hasEnchantment(armor, CEnchantments.ENLIGHTENED) && CEnchantments.ENLIGHTENED.chanceSuccessful(armor) && player.getHealth() > 0) {
                                 new BukkitRunnable() {
                                     @Override
                                     public void run() {
@@ -416,13 +416,13 @@ public class Armor implements Listener {
                                 if (CEnchantments.NURSERY.chanceSuccessful(armor)) {
                                     //Uses getValue as if the player has health boost it is modifying the base so the value after the modifier is needed.
                                     double maxHealth = ce.useHealthAttributes() ? Objects.requireNonNull(player.getAttribute(Attribute.GENERIC_MAX_HEALTH)).getValue() : player.getMaxHealth();
-                                    if (maxHealth > player.getHealth()) {
+                                    if (maxHealth > player.getHealth() && player.getHealth() > 0) {
                                         new BukkitRunnable() {
                                             @Override
                                             public void run() {
                                                 EnchantmentUseEvent event = new EnchantmentUseEvent(player, CEnchantments.NURSERY.getEnchantment(), armor);
                                                 Bukkit.getPluginManager().callEvent(event);
-                                                if (!event.isCancelled()) {
+                                                if (!event.isCancelled() && player.getHealth() > 0) {
                                                     if (player.getHealth() + heal <= maxHealth) {
                                                         player.setHealth(player.getHealth() + heal);
                                                     }

--- a/plugin/src/main/java/me/badbones69/crazyenchantments/enchantments/Swords.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/enchantments/Swords.java
@@ -207,7 +207,7 @@ public class Swords implements Listener {
                             }
                         }
                     }
-                    if (enchantments.contains(CEnchantments.LIFESTEAL.getEnchantment()) && CEnchantments.LIFESTEAL.chanceSuccessful(item)) {
+                    if (enchantments.contains(CEnchantments.LIFESTEAL.getEnchantment()) && CEnchantments.LIFESTEAL.chanceSuccessful(item) && damager.getHealth() > 0) {
                         EnchantmentUseEvent event = new EnchantmentUseEvent(damager, CEnchantments.LIFESTEAL, item);
                         Bukkit.getPluginManager().callEvent(event);
                         if (!event.isCancelled()) {
@@ -237,7 +237,7 @@ public class Swords implements Listener {
                             }
                         }
                     }
-                    if (enchantments.contains(CEnchantments.VAMPIRE.getEnchantment()) && CEnchantments.VAMPIRE.chanceSuccessful(item)) {
+                    if (enchantments.contains(CEnchantments.VAMPIRE.getEnchantment()) && CEnchantments.VAMPIRE.chanceSuccessful(item) && damager.getHealth() > 0) {
                         EnchantmentUseEvent event = new EnchantmentUseEvent(damager, CEnchantments.VAMPIRE, item);
                         Bukkit.getPluginManager().callEvent(event);
                         if (!event.isCancelled()) {


### PR DESCRIPTION
Plugin now checks if the player is alive before healing them, which prevents having the double-death bug.
Tested on 1.16.5 on a production server